### PR TITLE
feat: blur content behind login modal

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -43,20 +43,21 @@ const IndexPage: React.FC<PageProps> = () => {
 	return (
 		<div className="min-h-screen">
 		<Header isLoggedIn={isAuthenticated} handleLogout={() => handleLogout(setIsAuthenticated)}/>
-			<main className="container mx-auto px-4 py-8">
-				<>	
-					{!isAuthenticated &&
-						<AuthModal
-							handleAuth={handleAuth}
-						/>
-					}
-					<WeightInput onAddWeight={addWeight}/>
-					<WeightChart data={weightData}/>
-					<DataHistoryViewer data={weightData} />
-				</>
-			</main>
-	  </div>
-	)
+                        <main className="container mx-auto px-4 py-8 relative">
+                                {!isAuthenticated && (
+                                        <div className="absolute inset-0 z-10 bg-background/60 backdrop-blur-sm" />
+                                )}
+                                {!isAuthenticated && (
+                                        <AuthModal handleAuth={handleAuth} />
+                                )}
+                                <div className={!isAuthenticated ? "pointer-events-none select-none" : ""}>
+                                        <WeightInput onAddWeight={addWeight}/>
+                                        <WeightChart data={weightData}/>
+                                        <DataHistoryViewer data={weightData} />
+                                </div>
+                        </main>
+          </div>
+        )
 }
 
 export default IndexPage


### PR DESCRIPTION
## Summary
- frost main content when user not authenticated so header stays sharp

## Testing
- `npm test` *(fails: Unable to find a label with the text of: What is your weight today?)*
- `npm run typecheck` *(fails: Binding element 'actions' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6b825d508329b3a00eefb25d2a41